### PR TITLE
Update JWK type definition. Make kty required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.1 - 2024-10-04
+
+### Changed
+
+- Updated `JWK` type and `kty` property made required.
+
 ## 1.2.0 - 2024-09-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meeco/sd-jwt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SD-JWT implementation in typescript",
   "scripts": {
     "build": "tsc",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,41 +1,69 @@
 export interface JWK {
-  /** JWK "alg" (Algorithm) Parameter. */
+  /** JWK "kty" (Key Type) Parameter */
+  kty: string;
+  /**
+   * JWK "alg" (Algorithm) Parameter
+   */
   alg?: string;
-  crv?: string;
-  d?: string;
-  dp?: string;
-  dq?: string;
-  e?: string;
-  /** JWK "ext" (Extractable) Parameter. */
-  ext?: boolean;
-  k?: string;
-  /** JWK "key_ops" (Key Operations) Parameter. */
+  /** JWK "key_ops" (Key Operations) Parameter */
   key_ops?: string[];
-  /** JWK "kid" (Key ID) Parameter. */
+  /** JWK "ext" (Extractable) Parameter */
+  ext?: boolean;
+  /** JWK "use" (Public Key Use) Parameter */
+  use?: string;
+  /** JWK "x5c" (X.509 Certificate Chain) Parameter */
+  x5c?: string[];
+  /** JWK "x5t" (X.509 Certificate SHA-1 Thumbprint) Parameter */
+  x5t?: string;
+  /** JWK "x5t#S256" (X.509 Certificate SHA-256 Thumbprint) Parameter */
+  'x5t#S256'?: string;
+  /** JWK "x5u" (X.509 URL) Parameter */
+  x5u?: string;
+  /** JWK "kid" (Key ID) Parameter */
   kid?: string;
-  /** JWK "kty" (Key Type) Parameter. */
-  kty?: string;
+  /**
+   * - EC JWK "crv" (Curve) Parameter
+   * - OKP JWK "crv" (The Subtype of Key Pair) Parameter
+   */
+  crv?: string;
+  /**
+   * - Private RSA JWK "d" (Private Exponent) Parameter
+   * - Private EC JWK "d" (ECC Private Key) Parameter
+   * - Private OKP JWK "d" (The Private Key) Parameter
+   */
+  d?: string;
+  /** Private RSA JWK "dp" (First Factor CRT Exponent) Parameter */
+  dp?: string;
+  /** Private RSA JWK "dq" (Second Factor CRT Exponent) Parameter */
+  dq?: string;
+  /** RSA JWK "e" (Exponent) Parameter */
+  e?: string;
+  /** Oct JWK "k" (Key Value) Parameter */
+  k?: string;
+  /** RSA JWK "n" (Modulus) Parameter */
   n?: string;
+  /**
+   * Private RSA JWK "oth" (Other Primes Info) Parameter
+   */
   oth?: Array<{
     d?: string;
     r?: string;
     t?: string;
   }>;
+  /** Private RSA JWK "p" (First Prime Factor) Parameter */
   p?: string;
+  /** Private RSA JWK "q" (Second Prime Factor) Parameter */
   q?: string;
+  /** Private RSA JWK "qi" (First CRT Coefficient) Parameter */
   qi?: string;
-  /** JWK "use" (Public Key Use) Parameter. */
-  use?: string;
+  /**
+   * - EC JWK "x" (X Coordinate) Parameter
+   * - OKP JWK "x" (The public key) Parameter
+   */
   x?: string;
+  /** EC JWK "y" (Y Coordinate) Parameter */
   y?: string;
-  /** JWK "x5c" (X.509 Certificate Chain) Parameter. */
-  x5c?: string[];
-  /** JWK "x5t" (X.509 Certificate SHA-1 Thumbprint) Parameter. */
-  x5t?: string;
-  /** "x5t#S256" (X.509 Certificate SHA-256 Thumbprint) Parameter. */
-  'x5t#S256'?: string;
-  /** JWK "x5u" (X.509 URL) Parameter. */
-  x5u?: string;
+
   [propName: string]: unknown;
 }
 

--- a/src/verifier.spec.ts
+++ b/src/verifier.spec.ts
@@ -46,6 +46,7 @@ describe('verifySDJWT', () => {
 
       const holderKey = await importJWK(holderJWK, header.alg);
       const verifiedKbJWT = await jwtVerify(kbjwt, holderKey);
+
       return !!verifiedKbJWT;
     };
   };


### PR DESCRIPTION
## 1.2.1 - 2024-10-04

### Changed

- Updated `JWK` type and `kty` property made required.

--- 

Setting `JWK` type to be inline with the one that `jose` library is using.