### PR TITLE
Added Comment to indicate _sd_hash claim

### DIFF
--- a/src/issuer.ts
+++ b/src/issuer.ts
@@ -4,6 +4,14 @@ import { IssueSDJWT } from './types.js';
 import { base64encode, combineSDJWT } from './helpers.js';
 import { IssueSDJWTError } from './errors.js';
 
+/**
+ * Issues a new Selectively Disclosable JWT (SD-JWT).
+ *
+ * Packs the provided payload based on the disclosureFrame,
+ * adds the `_sd_alg` claim (derived from the `hash.alg` option) to indicate
+ * the hashing algorithm used for disclosures.
+ *
+ *  */
 export const issueSDJWT: IssueSDJWT = async (header, payload, disclosureFrame, { signer, hash, generateSalt, cnf }) => {
   if (!signer || typeof signer !== 'function') {
     throw new IssueSDJWTError('Signer function is required');


### PR DESCRIPTION
> The payload MAY contain the _sd_alg key described in [Section 4.1.1](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-19.html#hash_function_claim).

Our implementation doesnt provide the `_sd_alg` claim directly via the payload, it is provided via the `hash.alg` field.

Added comment to make this clear. 

