### PR TITLE
fix: export SD-JWT constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meeco/sd-jwt",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meeco/sd-jwt",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/sd-jwt",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "SD-JWT implementation in typescript",
   "scripts": {
     "build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './common.js';
+export * from './constants.js';
 export * from './helpers.js';
 export * from './issuer.js';
 export * from './jsonpath.js';


### PR DESCRIPTION

  Re-export SD-JWT constants from the package index so consumers can import structural claim constants directly from `@meeco/sd-jwt`.
